### PR TITLE
Fixes for HP Zbook Studio x360, Ubuntu 19, shellcheck

### DIFF
--- a/auto-rotate
+++ b/auto-rotate
@@ -38,7 +38,7 @@ rotate_cursor() {
     done
 }
 
-monitor-sensor | awk '/Accelerometer orientation changed:/ { print $NF; fflush();}' | while read line
+monitor-sensor | awk -W interactive '/Accelerometer orientation changed:/ { print $NF; fflush();}' | while read line
 do
     echo $line
     # If we have external monitor connected, do not rotate

--- a/auto-rotate
+++ b/auto-rotate
@@ -30,7 +30,7 @@ EOF
 }
 
 rotate_cursor() {
-    pointers=$(xinput list | awk '/Virtual core pointer/ { printing=1 } /Virtual core keyboard/ { printing=0} { if (printing && (match($0, /ELAN/) || match($0, /Pen/) || match($0, /Touch/) )) { gsub(".*id=",""); print $1 } }')
+    pointers=$(xinput list | awk -W interactive '/Virtual core pointer/ { printing=1 } /Virtual core keyboard/ { printing=0} { if (printing && (match($0, /ELAN/) || match($0, /Pen/) || match($0, /Finger/) || match($0, /Touch/) )) { gsub(".*id=",""); print $1 } }')
     echo "rotate -- pointers: <<$pointers>> matrix: <<$*>>"
     for p in $pointers
     do

--- a/auto-rotate
+++ b/auto-rotate
@@ -11,7 +11,7 @@ export DISPLAY
 install_background() {
 
     export BACKDROP=~/.config/auto-rotate/${1}.jpg
-    if [ -f $BACKDROP ]
+    if [ -f "$BACKDROP" ]
     then
 cat << EOF | sh
     dbus-send --session --dest=org.kde.plasmashell --type=method_call /PlasmaShell org.kde.PlasmaShell.evaluateScript 'string:
@@ -34,16 +34,16 @@ rotate_cursor() {
     echo "rotate -- pointers: <<$pointers>> matrix: <<$*>>"
     for p in $pointers
     do
-        xinput set-prop $p "Coordinate Transformation Matrix" $*
+        xinput set-prop "$p" "Coordinate Transformation Matrix" $*
     done
 }
 
 monitor-sensor | awk -W interactive '/Accelerometer orientation changed:/ { print $NF; fflush();}' | while read line
 do
-    echo $line
+    echo "$line"
     # If we have external monitor connected, do not rotate
     nscreens=$(xrandr  | grep -c " connected")
-    if [ $nscreens != 1 ]
+    if [ "$nscreens" != 1 ]
     then
         line=normal
     fi

--- a/auto-rotate
+++ b/auto-rotate
@@ -34,10 +34,12 @@ rotate_cursor() {
     echo "rotate -- pointers: <<$pointers>> matrix: <<$*>>"
     for p in $pointers
     do
-        xinput set-prop "$p" "Coordinate Transformation Matrix" $*
+        xinput set-prop "$p" "Coordinate Transformation Matrix" "$@"
     done
 }
 
+MAIN_SCREEN=$(xrandr --current | grep connected | awk -W interactive '/primary/ {print $1}')
+echo "$MAIN_SCREEN"
 monitor-sensor | awk -W interactive '/Accelerometer orientation changed:/ { print $NF; fflush();}' | while read -r line
 do
     echo "$line"
@@ -53,28 +55,28 @@ do
         normal)
             # re-enable backlight
             dbus-send --print-reply=literal --type=method_call --system --dest=org.freedesktop.UPower /org/freedesktop/UPower/KbdBacklight org.freedesktop.UPower.KbdBacklight.SetBrightness int32:1
-            xrandr --output eDP-1 --rotate normal
+            xrandr --output "$MAIN_SCREEN" --rotate normal
             rotate_cursor 1 0 0 0 1 0 0 0 1
             install_background normal
             ;;
         bottom-up)
             # disable backlight
             dbus-send --print-reply=literal --type=method_call --system --dest=org.freedesktop.UPower /org/freedesktop/UPower/KbdBacklight org.freedesktop.UPower.KbdBacklight.SetBrightness int32:0
-            xrandr --output eDP-1 --rotate inverted
+            xrandr --output "$MAIN_SCREEN" --rotate inverted
             rotate_cursor -1 0 1 0 -1 1 0 0 1
             install_background bottom-up
             ;;
         right-up)
             # disable backlight
             dbus-send --print-reply=literal --type=method_call --system --dest=org.freedesktop.UPower /org/freedesktop/UPower/KbdBacklight org.freedesktop.UPower.KbdBacklight.SetBrightness int32:0
-            xrandr --output eDP-1 --rotate right
+            xrandr --output "$MAIN_SCREEN" --rotate right
             rotate_cursor 0 1 0 -1 0 1 0 0 1
             install_background right-up
             ;;
         left-up)
             # disable backlight
             dbus-send --print-reply=literal --type=method_call --system --dest=org.freedesktop.UPower /org/freedesktop/UPower/KbdBacklight org.freedesktop.UPower.KbdBacklight.SetBrightness int32:0
-            xrandr --output eDP-1 --rotate left
+            xrandr --output "$MAIN_SCREEN" --rotate left
             rotate_cursor 0 -1 1 1 0 0 0 0 1
             install_background left-up
             ;;

--- a/auto-rotate
+++ b/auto-rotate
@@ -38,7 +38,7 @@ rotate_cursor() {
     done
 }
 
-monitor-sensor | awk -W interactive '/Accelerometer orientation changed:/ { print $NF; fflush();}' | while read line
+monitor-sensor | awk -W interactive '/Accelerometer orientation changed:/ { print $NF; fflush();}' | while read -r line
 do
     echo "$line"
     # If we have external monitor connected, do not rotate


### PR DESCRIPTION
1. Default version of awk on  Ubuntu 19 is mawk. Adding "-W interactive" means script works with both mawk and gawk so "auto-rotate" now works natively on Ubuntu without the need to add add gawk.  ( 86bd59f ) 

2. Fixed  hardcoding of screen name ( 7fa0f25 ) 

3. Add touchscreen cursor rotation. ( fe33846 ) 

4. Shellcheck errors: Updates to script to fix possible word splitting/globbing and/or mangling of backslashes. 

Tested the script "auto-rotate" and it seems to work on the x360 perfectly now. 